### PR TITLE
Use jsonschema for template settings validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ packaging
 pygetwindow
 PyMuPDF
 Pillow
+jsonschema

--- a/tests/test_template_settings.py
+++ b/tests/test_template_settings.py
@@ -1,5 +1,6 @@
 import unittest
 import tempfile
+import json
 from pathlib import Path
 from unittest.mock import patch
 from utils.common import (
@@ -43,6 +44,14 @@ class TemplateSettingsTest(unittest.TestCase):
 
     def test_save_and_load(self):
         with tempfile.TemporaryDirectory() as tmp:
+            schema = {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "title": "Template settings",
+                "type": "object",
+                "properties": {"rotation": {"type": "integer"}},
+                "additionalProperties": False,
+            }
+            Path(tmp, "schema.json").write_text(json.dumps(schema))
             with patch("utils.common.TEMPLATE_SETTINGS_DIR", Path(tmp)):
                 save_template_settings("ZZ0001", {"rotation": 45})
                 data = load_template_settings("ZZ0001")
@@ -50,8 +59,27 @@ class TemplateSettingsTest(unittest.TestCase):
 
     def test_validation(self):
         self.assertTrue(validate_template_settings({"rotation": 90}))
-        self.assertFalse(validate_template_settings({"rotation": "90"}))
-        self.assertFalse(validate_template_settings({"extra": 1}))
+        with self.assertRaises(ValueError):
+            validate_template_settings({"rotation": "90"})
+        with self.assertRaises(ValueError):
+            validate_template_settings({"extra": 1})
+
+    def test_validation_schema_change(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Template settings",
+            "type": "object",
+            "required": ["rotation"],
+            "properties": {"rotation": {"type": "integer"}},
+            "additionalProperties": False,
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = Path(tmp) / "schema.json"
+            schema_path.write_text(json.dumps(schema))
+            with patch("utils.common.TEMPLATE_SETTINGS_DIR", Path(tmp)):
+                with self.assertRaises(ValueError) as ctx:
+                    validate_template_settings({})
+                self.assertIn("rotation", str(ctx.exception))
 
 if __name__ == "__main__":
     unittest.main()

--- a/utils/common.py
+++ b/utils/common.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import jsonschema
 import sys
 from pathlib import Path
 
@@ -44,25 +45,24 @@ def load_template_settings(code: str) -> dict:
 
 
 def validate_template_settings(data: dict) -> bool:
-    """Return True if the given dictionary follows ``schema.json``."""
-    if not isinstance(data, dict):
-        return False
-    allowed = {"rotation", "bleedPaths"}
-    if not all(k in allowed for k in data):
-        return False
-    if "rotation" in data and not isinstance(data["rotation"], int):
-        return False
-    if "bleedPaths" in data:
-        bp = data["bleedPaths"]
-        if not isinstance(bp, list) or not all(isinstance(x, str) for x in bp):
-            return False
+    """Validate ``data`` against ``schema.json``.
+
+    Returns True if ``data`` is valid; otherwise raises ``ValueError`` with a
+    descriptive message.
+    """
+    schema_path = TEMPLATE_SETTINGS_DIR / "schema.json"
+    with schema_path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as exc:
+        raise ValueError(f"Invalid template settings: {exc.message}") from exc
     return True
 
 
 def save_template_settings(code: str, data: dict) -> None:
     """Write ``data`` as JSON for the given template ``code``."""
-    if not validate_template_settings(data):
-        raise ValueError("Invalid template settings")
+    validate_template_settings(data)
     path = TEMPLATE_SETTINGS_DIR / f"{code.upper()}.json"
     TEMPLATE_SETTINGS_DIR.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- validate template settings using `jsonschema` and raise descriptive errors
- depend on `jsonschema`
- expand template settings tests for invalid data and schema changes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fcc903bc4832da166d3e61d84d7de