### PR TITLE
Preserve fields when editing template settings

### DIFF
--- a/order_gui.py
+++ b/order_gui.py
@@ -32,6 +32,7 @@ from utils.common import (
     get_laminate_color,
     load_template_settings,
     save_template_settings,
+    update_template_settings,
     is_coffee_sleeve,
     is_pb001,
     is_pb005,
@@ -1446,6 +1447,7 @@ class App:
 
         rotation_var = tk.StringVar()
         bleed_var = tk.StringVar()
+        status_var = tk.StringVar()
 
         def load_selected(event=None):
             sel = self.ts_list.curselection()
@@ -1469,21 +1471,30 @@ class App:
             sel = self.ts_list.curselection()
             if not sel:
                 return
-            code = codes[sel[0]]
-            data = {}
+            idx = sel[0]
+            code = codes[idx]
+            updates: dict[str, object] = {}
             rot_text = rotation_var.get().strip()
             if rot_text:
                 try:
-                    data["rotation"] = int(rot_text)
+                    updates["rotation"] = int(rot_text)
                 except ValueError:
                     messagebox.showerror("Error", "Rotation must be an integer")
                     return
+            else:
+                updates["rotation"] = None
             paths = [p.strip() for p in re.split(r"[,\s]+", bleed_var.get()) if p.strip()]
             if paths:
-                data["bleedPaths"] = paths
+                updates["bleedPaths"] = paths
+            else:
+                updates["bleedPaths"] = None
             try:
-                save_template_settings(code, data)
+                update_template_settings(code, updates)
                 refresh_list()
+                self.ts_list.selection_set(idx)
+                load_selected()
+                status_var.set("Saved")
+                win.after(2000, lambda: status_var.set(""))
             except Exception as exc:
                 messagebox.showerror("Error", str(exc))
 
@@ -1525,6 +1536,9 @@ class App:
         tk.Button(btn_frame, text="Save", command=save).pack(side="left", padx=2)
         tk.Button(btn_frame, text="Add", command=add_new).pack(side="left", padx=2)
         tk.Button(btn_frame, text="Delete", command=delete_selected).pack(side="left", padx=2)
+        tk.Label(edit_frame, textvariable=status_var, fg="green").grid(
+            row=3, column=0, columnspan=2, sticky="w"
+        )
 
         refresh_list()
 

--- a/tests/test_template_settings.py
+++ b/tests/test_template_settings.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from utils.common import (
     load_template_settings,
     save_template_settings,
+    update_template_settings,
     validate_template_settings,
 )
 
@@ -56,6 +57,30 @@ class TemplateSettingsTest(unittest.TestCase):
                 save_template_settings("ZZ0001", {"rotation": 45})
                 data = load_template_settings("ZZ0001")
                 self.assertEqual(data["rotation"], 45)
+
+    def test_update_preserves_other_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "title": "Template settings",
+                "type": "object",
+                "properties": {
+                    "rotation": {"type": "integer"},
+                    "bleedPaths": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "additionalProperties": False,
+            }
+            Path(tmp, "schema.json").write_text(json.dumps(schema))
+            existing = {"rotation": 90, "bleedPaths": ["A", "B"]}
+            Path(tmp, "ZZ0001.json").write_text(json.dumps(existing))
+            with patch("utils.common.TEMPLATE_SETTINGS_DIR", Path(tmp)):
+                update_template_settings("ZZ0001", {"rotation": 180})
+                data = load_template_settings("ZZ0001")
+                self.assertEqual(data["rotation"], 180)
+                self.assertEqual(data["bleedPaths"], ["A", "B"])
 
     def test_validation(self):
         self.assertTrue(validate_template_settings({"rotation": 90}))

--- a/utils/common.py
+++ b/utils/common.py
@@ -69,6 +69,20 @@ def save_template_settings(code: str, data: dict) -> None:
         json.dump(data, f, ensure_ascii=False, indent=2)
 
 
+def update_template_settings(code: str, updates: dict) -> None:
+    """Merge ``updates`` into existing settings for ``code`` and save.
+
+    ``updates`` may include ``None`` values to remove keys from the settings.
+    """
+    data = load_template_settings(code)
+    for key, value in updates.items():
+        if value is None:
+            data.pop(key, None)
+        else:
+            data[key] = value
+    save_template_settings(code, data)
+
+
 def is_coffee_sleeve(template: str) -> bool:
     """Return True if the template code indicates a coffee sleeve."""
     return template.strip().upper() == "CD0434" if template else False
@@ -89,6 +103,7 @@ __all__ = [
     "get_laminate_color",
     "load_template_settings",
     "save_template_settings",
+    "update_template_settings",
     "validate_template_settings",
     "is_coffee_sleeve",
     "is_pb001",


### PR DESCRIPTION
## Summary
- Merge template updates with existing JSON so unrelated fields remain
- Add status feedback and keep selection after saving in template editor
- Add `update_template_settings` helper and tests covering field preservation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fcd95be98832da45ece753f6eac80