### PR TITLE
Prompt to create missing template settings

### DIFF
--- a/loading_window.py
+++ b/loading_window.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 import time
 import tkinter as tk
-from tkinter import scrolledtext, ttk
+from tkinter import scrolledtext, ttk, messagebox
 import tkinter.font as tkfont
 from pathlib import Path
 import json
@@ -57,6 +57,9 @@ class LoadingWindow:
         if width and height:
             self.window.geometry(f"{width}x{height}")
         self.window.resizable(False, False)
+
+        # Track templates without settings already prompted to avoid repeats
+        self.missing_settings: set[str] = set()
 
         style = ttk.Style(self.window)
         style.configure("LargePB.Horizontal.TProgressbar", thickness=20, troughcolor="#eee")
@@ -330,6 +333,26 @@ class LoadingWindow:
             specials = []
             tmpl_code = self.items[pair_idx].get("template", "")
             settings = load_template_settings(tmpl_code)
+            if not settings and tmpl_code and tmpl_code not in self.missing_settings:
+                self.missing_settings.add(tmpl_code)
+                if messagebox.askyesno(
+                    "Missing Template Settings",
+                    f"No settings found for {tmpl_code}. Create now?",
+                    parent=self.window,
+                ):
+                    self._append(
+                        self.log_box,
+                        f"Opened template settings editor for {tmpl_code}",
+                    )
+                    try:
+                        self.parent.open_template_settings_editor(tmpl_code)
+                    except Exception as exc:
+                        messagebox.showerror("Error", str(exc), parent=self.window)
+                else:
+                    self._append(
+                        self.log_box,
+                        f"Skipped creating settings for {tmpl_code}",
+                    )
             self.setting_disp_var.set(tmpl_code)
             color = "#FF00FF" if settings else "#00FF00"
             self.setting_entry.config(

--- a/order_gui.py
+++ b/order_gui.py
@@ -753,6 +753,8 @@ def populate_pairs(
 class App:
     def __init__(self, root: tk.Tk):
         self.root = root
+        # Expose template settings editor to other windows
+        root.open_template_settings_editor = self.open_template_settings_editor
         root.title("Illustrator Automation")
         try:
             fonts = [
@@ -1422,8 +1424,11 @@ class App:
                 text.insert(tk.END, f"    {name}: {reason}\n")
         text.config(state="disabled")
 
-    def open_template_settings_editor(self):
-        """Open a dialog for editing template settings JSON files."""
+    def open_template_settings_editor(self, code: str | None = None):
+        """Open a dialog for editing template settings JSON files.
+
+        If ``code`` is provided, ensure an entry exists and select it for editing.
+        """
         win = tk.Toplevel(self.root)
         win.title("Template Settings")
 
@@ -1577,6 +1582,18 @@ class App:
 
         tree.tag_configure("unsaved", background="#fff3cd")
         refresh_table()
+        if code:
+            code = code.strip().upper()
+            path = TEMPLATE_SETTINGS_DIR / f"{code}.json"
+            if not path.exists():
+                try:
+                    save_template_settings(code, {})
+                    refresh_table()
+                except Exception as exc:
+                    messagebox.showerror("Error", str(exc))
+            if path.exists():
+                tree.selection_set(code)
+                load_selected()
 
     def save_settings(self):
         data = {


### PR DESCRIPTION
## Summary
- Prompt user to create template settings when none found during processing
- Allow editor to open pre-filled for a specific template code
- Expose settings editor to other windows for direct access

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fcfd4ef9c832d9eac70b063e2de11