### PR TITLE
Add import/export for template settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ Omit any fields to use the defaults. When a template code matches one of these f
 
 Use **Settings → Template Settings** in the GUI to add, edit or remove these files without leaving the application. Current entries include rotation settings for `RT2052`, `RT3714`, `RT3712`, `RT3056`, `RT3055`, `TT3055`, `SL3302`, `TT3056`, `TT3075` and `RT3734`.
 
+Use the **Export** and **Import** buttons in that dialog to back up the entire
+`template_settings` folder to a ZIP archive or restore from one. Importing will
+prompt for confirmation before overwriting existing files.
+
 ## License
 
 This repository is provided without a specific license. See `AGENTS.md` for project information.

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -119,6 +119,8 @@ Example:
 The program automatically loads these files when processing a matching template.
 
 Open the **Template Settings** dialog from the Settings tab to create, edit or delete these JSON files directly from the GUI.
+Use the **Export** button to save all settings to a ZIP archive and **Import** to
+restore them. Importing asks for confirmation before overwriting existing files.
 
 ## 12. Additional Notes
 

--- a/order_gui.py
+++ b/order_gui.py
@@ -33,6 +33,8 @@ from utils.common import (
     load_template_settings,
     save_template_settings,
     update_template_settings,
+    export_template_settings,
+    import_template_settings,
     is_coffee_sleeve,
     is_pb001,
     is_pb005,
@@ -1570,6 +1572,45 @@ class App:
                 except Exception as exc:
                     messagebox.showerror("Error", str(exc))
 
+        def export_settings():
+            path = filedialog.asksaveasfilename(
+                title="Export Template Settings",
+                defaultextension=".zip",
+                filetypes=[("ZIP files", "*.zip"), ("All files", "*.*")],
+            )
+            if not path:
+                return
+            try:
+                export_template_settings(path)
+                messagebox.showinfo("Exported", f"Settings exported to {path}")
+            except Exception as exc:
+                messagebox.showerror("Error", str(exc))
+
+        def import_settings():
+            path = filedialog.askopenfilename(
+                title="Import Template Settings",
+                filetypes=[("ZIP files", "*.zip"), ("All files", "*.*")],
+            )
+            if not path:
+                return
+            try:
+                import_template_settings(path, overwrite=False)
+            except FileExistsError:
+                if not messagebox.askyesno(
+                    "Overwrite?",
+                    "Importing will overwrite existing settings. Continue?",
+                ):
+                    return
+                try:
+                    import_template_settings(path, overwrite=True)
+                except Exception as exc:
+                    messagebox.showerror("Error", str(exc))
+                    return
+            except Exception as exc:
+                messagebox.showerror("Error", str(exc))
+                return
+            refresh_table()
+
         btn_frame = tk.Frame(edit_frame)
         btn_frame.grid(row=2, column=0, columnspan=2, pady=5)
         save_btn = tk.Button(btn_frame, text="Save", state="disabled", command=save)
@@ -1579,6 +1620,10 @@ class App:
         tk.Label(edit_frame, textvariable=status_var, fg="green").grid(
             row=3, column=0, columnspan=2, sticky="w"
         )
+        io_frame = tk.Frame(edit_frame)
+        io_frame.grid(row=4, column=0, columnspan=2, pady=5)
+        tk.Button(io_frame, text="Export", command=export_settings).pack(side="left", padx=2)
+        tk.Button(io_frame, text="Import", command=import_settings).pack(side="left", padx=2)
 
         tree.tag_configure("unsaved", background="#fff3cd")
         refresh_table()

--- a/tests/test_template_settings.py
+++ b/tests/test_template_settings.py
@@ -8,6 +8,8 @@ from utils.common import (
     save_template_settings,
     update_template_settings,
     validate_template_settings,
+    export_template_settings,
+    import_template_settings,
 )
 
 class TemplateSettingsTest(unittest.TestCase):
@@ -105,6 +107,31 @@ class TemplateSettingsTest(unittest.TestCase):
                 with self.assertRaises(ValueError) as ctx:
                     validate_template_settings({})
                 self.assertIn("rotation", str(ctx.exception))
+
+    def test_export_import(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "title": "Template settings",
+                "type": "object",
+                "properties": {"rotation": {"type": "integer"}},
+                "additionalProperties": False,
+            }
+            Path(tmp, "schema.json").write_text(json.dumps(schema))
+            Path(tmp, "AA0001.json").write_text(json.dumps({"rotation": 90}))
+            with patch("utils.common.TEMPLATE_SETTINGS_DIR", Path(tmp)):
+                archive = Path(tmp, "settings.zip")
+                export_template_settings(archive)
+                Path(tmp, "AA0001.json").unlink()
+                import_template_settings(archive)
+                data = load_template_settings("AA0001")
+                self.assertEqual(data["rotation"], 90)
+                Path(tmp, "AA0001.json").write_text(json.dumps({"rotation": 45}))
+                with self.assertRaises(FileExistsError):
+                    import_template_settings(archive)
+                import_template_settings(archive, overwrite=True)
+                data = load_template_settings("AA0001")
+                self.assertEqual(data["rotation"], 90)
 
 if __name__ == "__main__":
     unittest.main()

--- a/utils/common.py
+++ b/utils/common.py
@@ -6,6 +6,7 @@ import json
 import jsonschema
 import sys
 from pathlib import Path
+import zipfile
 
 if getattr(sys, "frozen", False):
     APP_DIR = Path(getattr(sys, "_MEIPASS", Path(sys.executable).parent))
@@ -83,6 +84,47 @@ def update_template_settings(code: str, updates: dict) -> None:
     save_template_settings(code, data)
 
 
+def export_template_settings(archive_path: str | Path) -> Path:
+    """Write all files from ``template_settings`` to a ZIP archive.
+
+    Returns the ``Path`` to the created archive.
+    """
+    dest = Path(archive_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as zf:
+        for file in TEMPLATE_SETTINGS_DIR.glob("*.json"):
+            zf.write(file, arcname=file.name)
+    return dest
+
+
+def import_template_settings(archive_path: str | Path, *, overwrite: bool = False) -> None:
+    """Load template settings from ``archive_path`` into ``template_settings``.
+
+    If ``overwrite`` is ``False`` and any file already exists, ``FileExistsError``
+    is raised. Files are validated against ``schema.json`` before being
+    written.
+    """
+    src = Path(archive_path)
+    if not src.exists():
+        raise FileNotFoundError(src)
+
+    TEMPLATE_SETTINGS_DIR.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(src, "r") as zf:
+        for info in zf.infolist():
+            name = Path(info.filename).name
+            if not name.endswith(".json"):
+                continue
+            dest = TEMPLATE_SETTINGS_DIR / name
+            if name != "schema.json" and dest.exists() and not overwrite:
+                raise FileExistsError(dest)
+            with zf.open(info) as f:
+                data = json.load(f)
+            if name != "schema.json":
+                validate_template_settings(data)
+            with dest.open("w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+
+
 def is_coffee_sleeve(template: str) -> bool:
     """Return True if the template code indicates a coffee sleeve."""
     return template.strip().upper() == "CD0434" if template else False
@@ -104,6 +146,8 @@ __all__ = [
     "load_template_settings",
     "save_template_settings",
     "update_template_settings",
+    "export_template_settings",
+    "import_template_settings",
     "validate_template_settings",
     "is_coffee_sleeve",
     "is_pb001",


### PR DESCRIPTION
## Summary
- add helpers to bundle template settings into a zip archive and restore from one
- provide export/import buttons in Template Settings dialog with overwrite confirmation
- document how to back up and restore template settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fd1ba77cc832d97efc7026a417581