### PR TITLE
Expand template settings schema with mirroring and scaling options

### DIFF
--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -105,18 +105,20 @@ Pairs are aligned by index (`#1`, `#2`, etc.) so each table row corresponds to a
 
 ## 11. Template Settings
 
-Place JSON files inside `template_settings/` to define behaviors for specific templates. Each file name should match the template code and may specify a rotation angle and additional bleed path names.
+Place JSON files inside `template_settings/` to define behaviors for specific templates. Each file name should match the template code and may specify a rotation angle, additional bleed path names, whether the artwork should be mirrored, or a scale factor override.
 
 Example:
 
 ```json
 {
   "rotation": 90,
+  "mirror": true,
+  "artworkScale": 0.95,
   "bleedPaths": ["bleed1", "bleed2"]
 }
 ```
 
-The program automatically loads these files when processing a matching template.
+Existing settings files remain valid. To migrate, simply add `mirror` or `artworkScale` only to templates that require those overrides. The program automatically loads these files when processing a matching template.
 
 Open the **Template Settings** dialog from the Settings tab to create, edit or delete these JSON files directly from the GUI.
 Use the **Export** button to save all settings to a ZIP archive and **Import** to

--- a/template_creator.jsx
+++ b/template_creator.jsx
@@ -1238,6 +1238,15 @@ function processPair(pair, index) {
                 pasted.rotate(rot, true, true, true, true, Transformation.CENTER);
             }
         }
+        if (settings.mirror) {
+            writeProgress('  Mirroring artwork');
+            pasted.resize(-100, 100, true, true, true, true, 100, Transformation.CENTER);
+        }
+        var scale = (typeof settings.artworkScale === 'number') ? settings.artworkScale : 1;
+        if (scale && scale !== 1) {
+            writeProgress('  Scaling artwork to ' + Math.round(scale * 100) + '%');
+            pasted.resize(scale * 100, scale * 100, true, true, true, true, scale * 100, Transformation.CENTER);
+        }
         waitStep();
 
         writeProgress('Aligning artwork');

--- a/template_settings/schema.json
+++ b/template_settings/schema.json
@@ -11,6 +11,15 @@
       "type": "array",
       "items": {"type": "string"},
       "description": "Additional bleed path names to use"
+    },
+    "mirror": {
+      "type": "boolean",
+      "description": "Mirror artwork horizontally before placement"
+    },
+    "artworkScale": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Scale factor applied to artwork (1 = 100%)"
     }
   },
   "additionalProperties": false

--- a/tests/test_template_settings.py
+++ b/tests/test_template_settings.py
@@ -45,6 +45,11 @@ class TemplateSettingsTest(unittest.TestCase):
         settings = load_template_settings("RT3722")
         self.assertEqual(settings.get("rotation"), 90)
 
+    def test_defaults_for_new_fields(self):
+        settings = load_template_settings("RT3055")
+        self.assertFalse(settings.get("mirror"))
+        self.assertEqual(settings.get("artworkScale"), 1)
+
     def test_save_and_load(self):
         with tempfile.TemporaryDirectory() as tmp:
             schema = {
@@ -59,6 +64,25 @@ class TemplateSettingsTest(unittest.TestCase):
                 save_template_settings("ZZ0001", {"rotation": 45})
                 data = load_template_settings("ZZ0001")
                 self.assertEqual(data["rotation"], 45)
+
+    def test_mirror_and_scale_roundtrip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "title": "Template settings",
+                "type": "object",
+                "properties": {
+                    "mirror": {"type": "boolean"},
+                    "artworkScale": {"type": "number", "minimum": 0},
+                },
+                "additionalProperties": False,
+            }
+            Path(tmp, "schema.json").write_text(json.dumps(schema))
+            with patch("utils.common.TEMPLATE_SETTINGS_DIR", Path(tmp)):
+                save_template_settings("ZZ0002", {"mirror": True, "artworkScale": 0.5})
+                data = load_template_settings("ZZ0002")
+                self.assertTrue(data["mirror"])
+                self.assertEqual(data["artworkScale"], 0.5)
 
     def test_update_preserves_other_fields(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -86,8 +110,14 @@ class TemplateSettingsTest(unittest.TestCase):
 
     def test_validation(self):
         self.assertTrue(validate_template_settings({"rotation": 90}))
+        self.assertTrue(validate_template_settings({"mirror": True}))
+        self.assertTrue(validate_template_settings({"artworkScale": 1.2}))
         with self.assertRaises(ValueError):
             validate_template_settings({"rotation": "90"})
+        with self.assertRaises(ValueError):
+            validate_template_settings({"mirror": "yes"})
+        with self.assertRaises(ValueError):
+            validate_template_settings({"artworkScale": -1})
         with self.assertRaises(ValueError):
             validate_template_settings({"extra": 1})
 

--- a/utils/common.py
+++ b/utils/common.py
@@ -31,8 +31,12 @@ def get_laminate_color(name: str) -> str:
     return LAM_COLORS.get(key, "#000000")
 
 
-def load_template_settings(code: str) -> dict:
-    """Return per-template settings loaded from ``template_settings``."""
+def load_template_settings(code: str, *, defaults: bool = True) -> dict:
+    """Return per-template settings loaded from ``template_settings``.
+
+    When ``defaults`` is True, missing optional keys such as ``mirror`` and
+    ``artworkScale`` are populated with safe defaults.
+    """
     if not code:
         return {}
     path = TEMPLATE_SETTINGS_DIR / f"{code.upper()}.json"
@@ -40,7 +44,13 @@ def load_template_settings(code: str) -> dict:
         return {}
     try:
         with path.open("r", encoding="utf-8") as f:
-            return json.load(f)
+            data = json.load(f)
+        validate_template_settings(data)
+        if defaults:
+            data = dict(data)
+            data.setdefault("mirror", False)
+            data.setdefault("artworkScale", 1)
+        return data
     except Exception:
         return {}
 
@@ -75,7 +85,7 @@ def update_template_settings(code: str, updates: dict) -> None:
 
     ``updates`` may include ``None`` values to remove keys from the settings.
     """
-    data = load_template_settings(code)
+    data = load_template_settings(code, defaults=False)
     for key, value in updates.items():
         if value is None:
             data.pop(key, None)


### PR DESCRIPTION
## Summary
- allow template settings to specify `mirror` and `artworkScale`
- load settings with safe defaults and apply mirroring/scaling in Illustrator script
- document new overrides and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fd5723214832d91487ef8b08940be