### PR TITLE
Display version in about dialog

### DIFF
--- a/order_gui.py
+++ b/order_gui.py
@@ -54,6 +54,7 @@ from review import (
     ReviewManager,
     FLAG_REASONS,
 )
+from utils.version import get_version
 try:
     import pygetwindow as gw
 except Exception:
@@ -1403,7 +1404,10 @@ class App:
         """Display program information."""
         messagebox.showinfo(
             "About",
-            "Illustrator Automation GUI\nProvides batch template processing via Illustrator.",
+            (
+                f"Illustrator Automation GUI v{get_version()}\n"
+                "Provides batch template processing via Illustrator."
+            ),
         )
 
     def show_dashboard(self):


### PR DESCRIPTION
## Summary
- import the shared get_version utility in the GUI module
- show the current project version in the About dialog using the runtime VERSION file

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a6b96908832d82f54188c515262c