### PR TITLE
Add alignment option to template settings

### DIFF
--- a/template_settings/schema.json
+++ b/template_settings/schema.json
@@ -20,6 +20,21 @@
       "type": "number",
       "minimum": 0,
       "description": "Scale factor applied to artwork (1 = 100%)"
+    },
+    "alignment": {
+      "type": "string",
+      "enum": [
+        "top-left",
+        "top-center",
+        "top-right",
+        "center-left",
+        "center",
+        "center-right",
+        "bottom-left",
+        "bottom-center",
+        "bottom-right"
+      ],
+      "description": "Anchor point for placing artwork"
     }
   },
   "additionalProperties": false

--- a/tests/test_template_settings.py
+++ b/tests/test_template_settings.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 from utils.common import (
+    ALLOWED_ALIGNMENTS,
     load_template_settings,
     save_template_settings,
     update_template_settings,
@@ -49,6 +50,7 @@ class TemplateSettingsTest(unittest.TestCase):
         settings = load_template_settings("RT3055")
         self.assertFalse(settings.get("mirror"))
         self.assertEqual(settings.get("artworkScale"), 1)
+        self.assertEqual(settings.get("alignment"), "center")
 
     def test_save_and_load(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -133,6 +135,7 @@ class TemplateSettingsTest(unittest.TestCase):
         self.assertTrue(validate_template_settings({"rotation": 90}))
         self.assertTrue(validate_template_settings({"mirror": True}))
         self.assertTrue(validate_template_settings({"artworkScale": 1.2}))
+        self.assertTrue(validate_template_settings({"alignment": "center"}))
         with self.assertRaises(ValueError):
             validate_template_settings({"rotation": "90"})
         with self.assertRaises(ValueError):
@@ -141,6 +144,28 @@ class TemplateSettingsTest(unittest.TestCase):
             validate_template_settings({"artworkScale": -1})
         with self.assertRaises(ValueError):
             validate_template_settings({"extra": 1})
+        with self.assertRaises(ValueError):
+            validate_template_settings({"alignment": "diagonal"})
+
+    def test_alignment_normalization(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "title": "Template settings",
+                "type": "object",
+                "properties": {
+                    "alignment": {
+                        "type": "string",
+                        "enum": ALLOWED_ALIGNMENTS,
+                    }
+                },
+                "additionalProperties": False,
+            }
+            Path(tmp, "schema.json").write_text(json.dumps(schema))
+            Path(tmp, "ZZ0003.json").write_text(json.dumps({"alignment": "TOP_LEFT"}))
+            with patch("utils.common.TEMPLATE_SETTINGS_DIR", Path(tmp)):
+                data = load_template_settings("ZZ0003")
+                self.assertEqual(data["alignment"], "top-left")
 
     def test_validation_schema_change(self):
         schema = {

--- a/utils/common.py
+++ b/utils/common.py
@@ -15,6 +15,18 @@ else:
 
 TEMPLATE_SETTINGS_DIR = APP_DIR / "template_settings"
 
+ALLOWED_ALIGNMENTS = [
+    "top-left",
+    "top-center",
+    "top-right",
+    "center-left",
+    "center",
+    "center-right",
+    "bottom-left",
+    "bottom-center",
+    "bottom-right",
+]
+
 LAM_COLORS = {
     "matte": "#FFA500",  # [255,165,0]
     "gloss": "#008000",  # [0,128,0]
@@ -51,11 +63,24 @@ def load_template_settings(code: str, *, defaults: bool = True) -> dict:
                     data[key] = caster(data[key])
                 except ValueError:
                     pass
+        if "alignment" in data:
+            alignment = data["alignment"]
+            if isinstance(alignment, str):
+                normalized = alignment.strip().lower().replace("_", "-").replace(" ", "-")
+                if normalized not in ALLOWED_ALIGNMENTS:
+                    raise ValueError(
+                        "Invalid template settings: alignment must be one of "
+                        + ", ".join(ALLOWED_ALIGNMENTS)
+                    )
+                data["alignment"] = normalized
+            else:
+                raise ValueError("Invalid template settings: alignment must be a string")
         validate_template_settings(data)
         if defaults:
             data = dict(data)
             data.setdefault("mirror", False)
             data.setdefault("artworkScale", 1)
+            data.setdefault("alignment", "center")
         return data
     except Exception:
         return {}
@@ -157,6 +182,7 @@ def is_pb005(template: str) -> bool:
 
 
 __all__ = [
+    "ALLOWED_ALIGNMENTS",
     "LAM_COLORS",
     "get_laminate_color",
     "load_template_settings",


### PR DESCRIPTION
## Summary
- extend the template settings schema with an optional alignment anchor property
- normalize and validate alignment values when loading settings and provide a default center alignment for existing templates
- update unit tests to cover the new alignment behavior and validation

## Testing
- `pytest tests/test_template_settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68d5cefdb738832d88325f41b8f76805