### PR TITLE
Fix paired art print folder resolution

### DIFF
--- a/order_gui.py
+++ b/order_gui.py
@@ -141,6 +141,26 @@ def resolve_print_output_folder(
         else:
             root = path.parent
 
+    # Some paired art exports include an intermediate ``art`` directory. In
+    # those cases we need to step up one more level to reach the order folder
+    # where the print directory lives. Additionally, if the expected print
+    # folder is missing at this level but exists one level higher, prefer the
+    # higher-level directory.
+    candidate_root = root
+    if candidate_root.name.lower() == "art":
+        candidate_root = candidate_root.parent
+    else:
+        folder_name = (
+            DIAGNOSTIC_PRINT_FOLDER_NAME if diagnostic else PRINT_FOLDER_NAME
+        )
+        if (
+            not (candidate_root / folder_name).exists()
+            and (candidate_root.parent / folder_name).exists()
+        ):
+            candidate_root = candidate_root.parent
+
+    root = candidate_root
+
     folder_name = DIAGNOSTIC_PRINT_FOLDER_NAME if diagnostic else PRINT_FOLDER_NAME
     return str(root / folder_name)
 

--- a/tests/test_print_folders.py
+++ b/tests/test_print_folders.py
@@ -34,6 +34,17 @@ class ResolvePrintFolderTest(unittest.TestCase):
             Path(folder), self.art_path.parents[2] / DIAGNOSTIC_PRINT_FOLDER_NAME
         )
 
+    def test_p_template_with_nested_art_directory(self):
+        nested_art = Path(
+            "/tmp/base/YBS/Vista/35198/art/Pair123/sub/page1.pdf"
+        )
+        folder = resolve_print_output_folder(
+            str(nested_art), template_code="PZ999"
+        )
+        self.assertEqual(
+            Path(folder), nested_art.parents[3] / PRINT_FOLDER_NAME
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure `resolve_print_output_folder` climbs above intermediate paired art directories before selecting the print folder
- add a regression test covering art extracted beneath an order-level `art` directory

## Testing
- pytest tests/test_print_folders.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df2a74122c832da8d4f742ee038b0c