### PR TITLE
Fix Illustrator pair selection alignment

### DIFF
--- a/order_gui.py
+++ b/order_gui.py
@@ -155,6 +155,39 @@ def resolve_print_output_folder(
     return str(root / folder_name)
 
 
+def build_aligned_selection(
+    items_src: Sequence[Mapping[str, Any]],
+    pairs_src: Sequence[Mapping[str, Any]] | None,
+    pair_flags: Sequence[Any] | None,
+) -> list[tuple[int, Mapping[str, Any], Mapping[str, Any] | None]]:
+    """Return the selected rows while keeping their original indices aligned."""
+
+    if not items_src:
+        return []
+
+    aligned: list[tuple[int, Mapping[str, Any], Mapping[str, Any] | None]] = []
+    if pair_flags:
+        for idx, (item, flag) in enumerate(zip(items_src, pair_flags)):
+            try:
+                selected = bool(flag.get())
+            except AttributeError:
+                selected = bool(flag)
+            if not selected:
+                continue
+            pair = None
+            if pairs_src and idx < len(pairs_src):
+                pair = pairs_src[idx]
+            aligned.append((idx, item, pair))
+    else:
+        for idx, item in enumerate(items_src):
+            pair = None
+            if pairs_src and idx < len(pairs_src):
+                pair = pairs_src[idx]
+            aligned.append((idx, item, pair))
+
+    return aligned
+
+
 def _guess_flat_filename(
     print_folder: str,
     paper: str,
@@ -3575,8 +3608,8 @@ class App:
         if not items_src:
             messagebox.showerror("Error", "No order data fetched")
             return
-        items = self.get_selected_items()
-        if not items:
+        aligned_rows = build_aligned_selection(items_src, pairs_src, self.pair_vars)
+        if not aligned_rows:
             messagebox.showerror("Error", "No pairs selected")
             return
         # Update current item edits
@@ -3588,13 +3621,16 @@ class App:
         pair_orders_src: list[str] = []
         pair_contexts: list[dict] = []
         flat_candidates: list[dict] = []
-        for idx, it in enumerate(items):
+        items = [item for _, item, _ in aligned_rows]
+        for _, it, pair_data in aligned_rows:
             art_id = ""
             template = ""
-            if pairs_src and idx < len(pairs_src):
-                art_id = pairs_src[idx].get("art_id", "")
-                template = pairs_src[idx].get("template", "")
-                order_id = pairs_src[idx].get("order_id", it.get("order_id", self.order_id_var.get()))
+            if pair_data:
+                art_id = pair_data.get("art_id", "")
+                template = pair_data.get("template", "")
+                order_id = pair_data.get(
+                    "order_id", it.get("order_id", self.order_id_var.get())
+                )
             else:
                 order_id = it.get("order_id", self.order_id_var.get())
             art_root = it.get("art_dir", self.art_dir_var.get())

--- a/tests/test_run_illustrator_alignment.py
+++ b/tests/test_run_illustrator_alignment.py
@@ -1,0 +1,101 @@
+"""Regression tests for the Illustrator launch workflow alignment."""
+
+from __future__ import annotations
+
+import tkinter as tk
+
+import pytest
+
+import order_gui
+
+
+@pytest.fixture
+def tk_root():
+    """Provide a Tk root window or skip if Tk is unavailable."""
+
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tkinter GUI is not available in this environment")
+    root.withdraw()
+    yield root
+    root.destroy()
+
+
+def test_run_illustrator_preserves_pair_alignment(tk_root, monkeypatch):
+    """Selecting later checklist rows keeps art/template metadata aligned."""
+
+    app = order_gui.App(tk_root)
+    app.items = [
+        {"filename": "first.ai", "order_id": "ORDER-1", "qty": 5},
+        {"filename": "second.ai", "order_id": "ORDER-2", "qty": 7},
+        {"filename": "third.ai", "order_id": "ORDER-3", "qty": 9},
+    ]
+    app.pairs = [
+        {"art_id": "ART-1", "template": "T1", "order_id": "ORDER-1"},
+        {"art_id": "ART-2", "template": "T2", "order_id": "ORDER-2"},
+        {"art_id": "ART-3", "template": "T3", "order_id": "ORDER-3"},
+    ]
+    app.batch_items = []
+    app.batch_pairs = []
+
+    app.pair_vars = [tk.BooleanVar(master=tk_root, value=False) for _ in app.items]
+    app.pair_vars[1].set(True)
+    app.pair_vars[2].set(True)
+
+    app.art_dir_var.set("/art")
+    app.template_dir_var.set("/templates")
+    app.month_dir_var.set("/month")
+    app.order_id_var.set("ORDER-DEFAULT")
+
+    monkeypatch.setattr(order_gui, "find_art_file", lambda *args, **kwargs: "art-path")
+    monkeypatch.setattr(order_gui, "find_template_file", lambda *args, **kwargs: "template-path")
+    monkeypatch.setattr(order_gui, "extract_paper_type", lambda *_: "Paper")
+    monkeypatch.setattr(order_gui, "detect_laminate", lambda *_: "")
+    monkeypatch.setattr(order_gui, "is_coffee_sleeve", lambda *_: False)
+    monkeypatch.setattr(order_gui, "get_item_quantity", lambda item: item.get("qty", 0))
+    monkeypatch.setattr(order_gui, "cut_file_for_template", lambda *_: "")
+    monkeypatch.setattr(order_gui, "resolve_paired_page_art", lambda *_1, **_2: ({}, set()))
+    monkeypatch.setattr(order_gui, "prepare_flat_review_entries", lambda *_1, **_2: ([], []))
+    monkeypatch.setattr(order_gui, "write_paper_summary", lambda *_: None)
+    monkeypatch.setattr(order_gui, "launch_illustrator", lambda *_: None)
+    monkeypatch.setattr(order_gui, "record_run_history", lambda *_: None)
+    monkeypatch.setattr(order_gui, "save_order_html", lambda *_: None)
+
+    class DummyLoader:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        def update_status(self, *_: object, **__: object) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    class DummyThread:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+    monkeypatch.setattr(order_gui, "LoadingWindow", DummyLoader)
+    monkeypatch.setattr(order_gui.threading, "Thread", DummyThread)
+
+    captured: dict[str, dict] = {}
+
+    def fake_save_order_data(payload: dict) -> None:
+        captured["payload"] = payload
+
+    monkeypatch.setattr(order_gui, "save_order_data", fake_save_order_data)
+
+    app.run_illustrator()
+
+    assert "payload" in captured
+    pairs = captured["payload"]["pairs"]
+    assert [p["art_id"] for p in pairs] == ["ART-2", "ART-3"]
+    assert [p["template"] for p in pairs] == ["T2", "T3"]
+    assert [item["filename"] for item in captured["payload"]["items"]] == [
+        "second.ai",
+        "third.ai",
+    ]


### PR DESCRIPTION
## Summary
- ensure Illustrator launch filters selected rows using their original indices so art/template metadata stays aligned
- add a regression test covering selections of later checklist entries and confirming the saved data references the right sources

## Testing
- pytest -vv tests/test_run_illustrator_alignment.py

------
https://chatgpt.com/codex/tasks/task_e_68e099b047b0832dbae39d9123bec840